### PR TITLE
Update Clojure, play-clj & libgdx deps

### DIFF
--- a/desktop/project.clj
+++ b/desktop/project.clj
@@ -1,31 +1,31 @@
 (defproject brute-play-pong "0.0.1-SNAPSHOT"
-    :description "FIXME: write description"
+  :description "FIXME: write description"
 
-    :dependencies [[com.badlogicgames.gdx/gdx "1.0.0"]
-                   [com.badlogicgames.gdx/gdx-backend-lwjgl "1.0.0"]
-                   [com.badlogicgames.gdx/gdx-box2d "1.0.0"]
-                   [com.badlogicgames.gdx/gdx-box2d-platform "1.0.0"
-                    :classifier "natives-desktop"]
-                   [com.badlogicgames.gdx/gdx-bullet "1.0.0"]
-                   [com.badlogicgames.gdx/gdx-bullet-platform "1.0.0"
-                    :classifier "natives-desktop"]
-                   [com.badlogicgames.gdx/gdx-platform "1.0.0"
-                    :classifier "natives-desktop"]
-                   [org.clojure/clojure "1.6.0"]
-                   [play-clj "0.3.0"]
-                   [brute "0.2.0"]
-                   [org.clojure/math.numeric-tower "0.0.4"]]
+  :dependencies [[com.badlogicgames.gdx/gdx "1.9.3"]
+                 [com.badlogicgames.gdx/gdx-backend-lwjgl "1.9.3"]
+                 [com.badlogicgames.gdx/gdx-box2d "1.9.3"]
+                 [com.badlogicgames.gdx/gdx-box2d-platform "1.9.3"
+                  :classifier "natives-desktop"]
+                 [com.badlogicgames.gdx/gdx-bullet "1.9.3"]
+                 [com.badlogicgames.gdx/gdx-bullet-platform "1.9.3"
+                  :classifier "natives-desktop"]
+                 [com.badlogicgames.gdx/gdx-platform "1.9.3"
+                  :classifier "natives-desktop"]
+                 [org.clojure/clojure "1.8.0"]
+                 [play-clj "1.1.0"]
+                 [brute "0.4.0"]
+                 [org.clojure/math.numeric-tower "0.0.4"]]
 
-    :source-paths ["src" "src-common"]
-    :javac-options ["-target" "1.6" "-source" "1.6" "-Xlint:-options"]
-    :aot [brute-play-pong.core.desktop-launcher]
-    :main brute-play-pong.core.desktop-launcher
-    :plugins [[lein-midje "3.1.1"]
-              [lein-ancient "0.5.5"]
-              [codox "0.6.7"]]
-    :profiles {:dev {:dependencies [[midje "1.6.3"]
-                                    [org.clojure/tools.namespace "0.2.4"]
-                                    [org.clojure/tools.trace "0.7.8"]
+  :source-paths ["src" "src-common"]
+  :javac-options ["-target" "1.6" "-source" "1.6" "-Xlint:-options"]
+  :aot [brute-play-pong.core.desktop-launcher]
+  :main brute-play-pong.core.desktop-launcher
+  :plugins [[lein-midje "3.1.1"]
+            [lein-ancient "0.6.10"]
+            [codox "0.6.7"]]
+  :profiles {:dev   {:dependencies [[midje "1.8.3"]
+                                    [org.clojure/tools.namespace "0.2.10"]
+                                    [org.clojure/tools.trace "0.7.9"]
                                     [org.clojars.gjahad/debug-repl "0.3.3"]]
                      :source-paths ["dev"]
                      :repl-options {:init-ns user}

--- a/desktop/src-common/brute_play_pong/rendering.clj
+++ b/desktop/src-common/brute_play_pong/rendering.clj
@@ -35,18 +35,18 @@
     "Render the scores"
     [system]
     (let [renderer (:renderer system)
-          sprite-batch (:sprite-batch renderer)
-          font (:font renderer)]
+          ^SpriteBatch sprite-batch (:sprite-batch renderer)
+          ^BitmapFont font (:font renderer)]
         (.begin sprite-batch)
         (doseq [entity (e/get-all-entities-with-component system Score)]
             (let [score (e/get-component system entity Score)
                   is-player (e/get-component system entity PlayerScore)
                   screen-width (graphics! :get-width)
                   screen-height (graphics! :get-height)
-                  str-score (str @(:score score))]
+                  ^CharSequence str-score (str @(:score score))]
                 (if is-player
-                    (.draw font sprite-batch str-score 15 30)
-                    (.draw font sprite-batch str-score (- screen-width 30) (- screen-height 15)))))
+                    (.draw font sprite-batch str-score 15.0 30.0)
+                    (.draw font sprite-batch str-score (float (- screen-width 30)) (float (- screen-height 15))))))
         (.end sprite-batch)))
 
 (defn process-one-game-tick


### PR DESCRIPTION
Update to Clojure 1.8, play-clj 1.1.0, brute 0.4.0 and libgdx 1.9.3.

Required type-hinting the draw() calls to BitmapFont in rendering.clj (as discussed on Slack)
